### PR TITLE
feat: use seq to seq transformer

### DIFF
--- a/.github/workflows/trigger.yml
+++ b/.github/workflows/trigger.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: ["master", "develop", "v*.*.*", "hotfix/*/*", "fix/*", "maint/*"]
+    branches: ["main", "develop", "v*.*.*", "hotfix/*/*", "fix/*", "maint/*", feat/*]
   pull_request:
-    branches: ["master"]
+    branches: ["main"]
 
 jobs:
   build_only:

--- a/examples/baseline.ipynb
+++ b/examples/baseline.ipynb
@@ -20,6 +20,8 @@
     "import tqdm\n",
     "import numpy as np\n",
     "\n",
+    "from fugashi import Tagger\n",
+    "from linalgo.annotate import Sequence2SequenceTransformer\n",
     "from linalgo.hub import BQClient\n",
     "\n",
     "from wsd.models import JMDict\n"
@@ -31,20 +33,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Fetch documents and annotations from BigQuery\n",
     "task_id = os.getenv('LINHUB_TASK')\n",
     "client = BQClient(task_id)\n",
-    "jmdict = JMDict()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "\n",
     "annotations = client.get_annotations()\n",
     "docs = client.get_documents()\n",
-    "docs = [doc for doc in docs if len(doc.annotations) > 0]"
+    "docs = [doc for doc in docs if len(doc.annotations) > 0]\n"
    ]
   },
   {
@@ -53,22 +48,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def get_offset(token):\n",
-    "    start = token.target.selector[0].start_offset\n",
-    "    end = token.target.selector[0].end_offset\n",
-    "    return start, end\n",
+    "# Use the baseline `JMDict` model to disambiguate.\n",
+    "jmdict = JMDict()\n",
     "\n",
     "y_pred = []\n",
-    "y_true = []\n",
     "for doc in tqdm.tqdm(docs):\n",
     "    yp = jmdict.predict(doc.content)\n",
-    "    yp = [y for y in yp if y is not None]\n",
-    "    yt = [a.body for a in sorted(doc.annotations, key=get_offset)]\n",
-    "    # TODO: Will break when more than one annotator\n",
-    "    if len(yt) == len(yp):  # Some documents are partially annotated.\n",
-    "        y_pred.extend(yp)\n",
-    "        y_true.extend(yt)\n",
-    "y_true = np.array(y_true)\n",
+    "    y_pred.extend(yp)\n",
     "y_pred = np.array(y_pred)\n"
    ]
   },
@@ -78,8 +64,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "acc = np.sum(y_true == y_pred) / len(y_true)\n",
-    "print(f\"accuracy = {acc:%}\")"
+    "# Retrieve the ground truth labels\n",
+    "tagger = Tagger('-Owakati')\n",
+    "\n",
+    "def tokenize(text):\n",
+    "    idx = 0\n",
+    "    for token in tagger(text):\n",
+    "        yield idx, token.surface\n",
+    "        idx += len(token.surface)\n",
+    "    \n",
+    "transformer = Sequence2SequenceTransformer(tokenize_fn=tokenize)\n",
+    "input_sequence, output_sequence = transformer.transform(docs)\n",
+    "y_true = np.array([yt for seq in output_sequence for yt in seq])"
    ]
   },
   {
@@ -87,12 +83,16 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# Compute accuracy\n",
+    "acc = np.sum(y_true == y_pred) / len(y_true)\n",
+    "print(f\"accuracy = {acc:%}\")"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "wsd",
    "language": "python",
    "name": "python3"
   },
@@ -106,7 +106,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.16"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ authors = [
 
 dependencies = [
   "fugashi[unidic]",
-  "linalgo @ git+https://github.com/linalgo/linalgo-sdk.git@master",
+  "linalgo @ git+https://github.com/linalgo/linalgo.git@master",
   "google-cloud-bigquery",
   "mesop",
   "pillow",

--- a/wsd/__init__.py
+++ b/wsd/__init__.py
@@ -1,4 +1,4 @@
 """Init file containing version and build"""
 
 __version__ = "0.0.1rc0"
-__build__ = "Mon Mar 24 00:25:42 JST 2025"
+__build__ = "Wed Mar 26 20:57:54 JST 2025"


### PR DESCRIPTION
Rewrote `examples/baseline.ipynb` to make use of the `Seq2SeqTransformer`.
The `Seq2SeqTransformer` transforms a task into a sequence to sequence ML dataset. This way, It should be easier to leverage other libs like sklearn, Tensorflow, etc.