### PR TITLE
feat: index dictionary and visualize definitions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/mirrors-pylint
-    rev: v2.7.4  # Specify the version of pylint you want to use
+    rev: v3.3.4  # Specify the version of pylint you want to use
     hooks:
       - id: pylint
         args: [--disable=C0103,--disable=R0903,--disable=R0914,--disable=E0401]  # Disable the invalid-name warning globally

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,8 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
-  - repo: https://github.com/pre-commit/mirrors-pylint
-    rev: v3.3.4  # Specify the version of pylint you want to use
+  - repo: https://github.com/pylint-dev/pylint
+    rev: v3.3.6  # Specify the version of pylint you want to use
     hooks:
       - id: pylint
         args: [--disable=C0103,--disable=R0903,--disable=R0914,--disable=E0401]  # Disable the invalid-name warning globally

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Alternatively, you can use the `predict` method to get the unique `ent_seq` of
 the best entry:
 
 ```python
-jmdict.search("かんじ")
+jmdict.predict("かんじ")
 # Output:
 # '1210280'
 ```

--- a/examples/baseline.ipynb
+++ b/examples/baseline.ipynb
@@ -57,23 +57,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "doc = docs[1]\n",
-    "for annotation in doc.annotations:\n",
-    "    entry = jmdict.get(annotation.body)\n",
-    "    body = {\n",
-    "        'ent_seq': entry.ent_seq,\n",
-    "        'kanji': [k.keb for k in entry.k_ele],\n",
-    "        'reading': [r.reb for r in entry.r_ele],\n",
-    "    }\n",
-    "    annotation.body = body"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "# Use the baseline `JMDict` model to disambiguate.\n",
     "y_pred = []\n",
     "for doc in tqdm.tqdm(docs):\n",
@@ -112,13 +95,6 @@
     "acc = np.sum(y_true == y_pred) / len(y_true)\n",
     "print(f\"accuracy = {acc:%}\")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/examples/baseline.ipynb
+++ b/examples/baseline.ipynb
@@ -22,9 +22,10 @@
     "\n",
     "from fugashi import Tagger\n",
     "from linalgo.annotate import Sequence2SequenceTransformer\n",
+    "from linalgo.annotate.display import init, display\n",
     "from linalgo.hub import BQClient\n",
     "\n",
-    "from wsd.models import JMDict\n"
+    "from wsd.models import JMDict"
    ]
   },
   {
@@ -35,11 +36,20 @@
    "source": [
     "# Fetch documents and annotations from BigQuery\n",
     "task_id = os.getenv('LINHUB_TASK')\n",
-    "client = BQClient(task_id)\n",
+    "client = BQClient(task_id, project='linalgo-infra')\n",
     "\n",
     "annotations = client.get_annotations()\n",
     "docs = client.get_documents()\n",
-    "docs = [doc for doc in docs if len(doc.annotations) > 0]\n"
+    "docs = [doc for doc in docs if len(doc.annotations) > 0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "jmdict = JMDict()"
    ]
   },
   {
@@ -49,13 +59,11 @@
    "outputs": [],
    "source": [
     "# Use the baseline `JMDict` model to disambiguate.\n",
-    "jmdict = JMDict()\n",
-    "\n",
     "y_pred = []\n",
     "for doc in tqdm.tqdm(docs):\n",
     "    yp = jmdict.predict(doc.content)\n",
     "    y_pred.extend(yp)\n",
-    "y_pred = np.array(y_pred)\n"
+    "y_pred = np.array(y_pred)"
    ]
   },
   {
@@ -72,10 +80,10 @@
     "    for token in tagger(text):\n",
     "        yield idx, token.surface\n",
     "        idx += len(token.surface)\n",
-    "    \n",
+    "\n",
     "transformer = Sequence2SequenceTransformer(tokenize_fn=tokenize)\n",
-    "input_sequence, output_sequence = transformer.transform(docs)\n",
-    "y_true = np.array([yt for seq in output_sequence for yt in seq])"
+    "input_sequences, output_sequences = transformer.transform(docs)\n",
+    "y_true = np.array([yt for seq in output_sequences for yt in seq])"
    ]
   },
   {
@@ -88,11 +96,18 @@
     "acc = np.sum(y_true == y_pred) / len(y_true)\n",
     "print(f\"accuracy = {acc:%}\")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "wsd",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -110,5 +125,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/examples/baseline.ipynb
+++ b/examples/baseline.ipynb
@@ -22,7 +22,6 @@
     "\n",
     "from fugashi import Tagger\n",
     "from linalgo.annotate import Sequence2SequenceTransformer\n",
-    "from linalgo.annotate.display import init, display\n",
     "from linalgo.hub import BQClient\n",
     "\n",
     "from wsd.models import JMDict"
@@ -50,6 +49,23 @@
    "outputs": [],
    "source": [
     "jmdict = JMDict()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "doc = docs[1]\n",
+    "for annotation in doc.annotations:\n",
+    "    entry = jmdict.get(annotation.body)\n",
+    "    body = {\n",
+    "        'ent_seq': entry.ent_seq,\n",
+    "        'kanji': [k.keb for k in entry.k_ele],\n",
+    "        'reading': [r.reb for r in entry.r_ele],\n",
+    "    }\n",
+    "    annotation.body = body"
    ]
   },
   {

--- a/examples/vizualize.ipynb
+++ b/examples/vizualize.ipynb
@@ -57,33 +57,6 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "jmdict.search('感じ')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from dataclasses import asdict"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "asdict(jmdict.feeling_lucky('感じ'))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": []
   }
  ],

--- a/examples/vizualize.ipynb
+++ b/examples/vizualize.ipynb
@@ -1,0 +1,304 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<style>\n",
+       "    .underline {\n",
+       "        border-bottom: 1px dotted grey;\n",
+       "        cursor: pointer;\n",
+       "        margin-right: 3px;\n",
+       "    }\n",
+       "    .tooltip {\n",
+       "        white-space: pre;\n",
+       "        display: none;\n",
+       "        background: black;\n",
+       "        color: white;\n",
+       "        padding: 4px 8px;\n",
+       "        font-size: 13px;\n",
+       "        border-radius: 4px;\n",
+       "        max-width: 400px;\n",
+       "        text-wrap: wrap;\n",
+       "    }\n",
+       "\n",
+       "    .tooltip[data-show] {\n",
+       "        display: block;\n",
+       "    }\n",
+       "    .arrow,\n",
+       "    .arrow::before {\n",
+       "        position: absolute;\n",
+       "        width: 8px;\n",
+       "        height: 8px;\n",
+       "        background: inherit;\n",
+       "    }\n",
+       "\n",
+       "    .arrow {\n",
+       "        visibility: hidden;\n",
+       "    }\n",
+       "\n",
+       "    .arrow::before {\n",
+       "        visibility: visible;\n",
+       "        content: '';\n",
+       "        transform: rotate(45deg);\n",
+       "    }\n",
+       "    .tooltip[data-popper-placement^='top'] > .arrow {\n",
+       "        bottom: -4px;\n",
+       "    }\n",
+       "\n",
+       "    .tooltip[data-popper-placement^='bottom'] > .arrow {\n",
+       "        top: -4px;\n",
+       "    }\n",
+       "\n",
+       "    .tooltip[data-popper-placement^='left'] > .arrow {\n",
+       "        right: -4px;\n",
+       "    }\n",
+       "\n",
+       "    .tooltip[data-popper-placement^='right'] > .arrow {\n",
+       "        left: -4px;\n",
+       "    }\n",
+       "</style>\n",
+       "<script type=\"text/javascript\" src=\"https://storage.googleapis.com/linhub.linalgo.com/linalgo.2.umd.js\"></script>\n",
+       "<script src=\"https://unpkg.com/@popperjs/core@2\"></script>\n",
+       "<script type=\"text/javascript\">\n",
+       "function annotate(selector, annotations) {\n",
+       "    const Annotator = window[\"@linalgo/annotate-core\"].Annotator\n",
+       "    const doc = document.querySelector(`[id='${selector}']`);\n",
+       "    const annotator = new Annotator(doc);\n",
+       "    for (annotation of annotations) {\n",
+       "        annotator.showAnnotation(annotation);\n",
+       "        const elements = document.querySelectorAll(`[id='${annotation.id}']`);\n",
+       "        elements.forEach(el => {\n",
+       "            el.classList.add(\"underline\");\n",
+       "            if (!el.textContent) {\n",
+       "                el.remove()\n",
+       "            }\n",
+       "        });\n",
+       "        const node = document.createElement(\"div\");\n",
+       "        const textnode = document.createTextNode(JSON.stringify(annotation.body, null, 2));\n",
+       "        const arrow = document.createElement(\"div\");\n",
+       "        node.setAttribute(\"role\", \"tooltip\");\n",
+       "        node.classList.add(\"tooltip\");\n",
+       "        arrow.setAttribute(\"data-popper-arrow\", \"\");\n",
+       "        arrow.classList.add(\"arrow\");\n",
+       "        doc.appendChild(node);\n",
+       "        node.appendChild(textnode);\n",
+       "        node.appendChild(arrow);\n",
+       "        elements.forEach(el => {\n",
+       "            const popperInstance = Popper.createPopper(el, node, {\n",
+       "                placement: 'bottom',\n",
+       "                modifiers: [\n",
+       "                    {\n",
+       "                        name: 'offset',\n",
+       "                        options: {\n",
+       "                            offset: [0, 8],\n",
+       "                        },\n",
+       "                    },\n",
+       "                ],\n",
+       "            })\n",
+       "            function show() {\n",
+       "                if (node.hasAttribute('data-show')) {\n",
+       "                    node.removeAttribute('data-show');\n",
+       "                } else {\n",
+       "                    node.setAttribute('data-show', '');\n",
+       "                }\n",
+       "                popperInstance.update();\n",
+       "            }\n",
+       "            el.addEventListener('click', show)\n",
+       "        });\n",
+       "    }\n",
+       "}\n",
+       "</script>\n",
+       "<div style=\"font-style: italic;\">Success!</div>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from linalgo.annotate import Document, Annotation\n",
+    "from linalgo.annotate.display import init, display\n",
+    "\n",
+    "from wsd.models import JMDict\n",
+    "\n",
+    "init()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 6.54 s, sys: 174 ms, total: 6.71 s\n",
+      "Wall time: 6.74 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "jmdict = JMDict()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "doc = Document(content=\"虎穴に入らずんば虎子を得ず\")\n",
+    "doc = jmdict.annotate(doc)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div id='97f40785079e44368386947e1f6cdf52' class='doc' style='min-height: 600px'>虎穴に入らずんば虎子を得ず</div>\n",
+       "<script type=\"text/javascript\">\n",
+       "  annotate('97f40785079e44368386947e1f6cdf52', [{\"id\": \"80b12f76-48e5-4a7f-ac68-01eafc82bab4\", \"task_id\": \"default\", \"entity_id\": \"default\", \"body\": {\"ent_seq\": \"1465580\", \"k_ele\": [{\"keb\": \"\\u5165\\u308b\", \"ke_inf\": [], \"ke_pri\": [\"ichi1\"], \"id\": 0}], \"r_ele\": [{\"reb\": \"\\u3044\\u308b\", \"re_nokanji\": false, \"re_restr\": [], \"re_inf\": [], \"re_pri\": [\"ichi1\"], \"id\": 0}], \"sense\": [{\"stagk\": [], \"stagr\": [], \"pos\": [\"Godan verb with 'ru' ending\", \"intransitive verb\"], \"xref\": [\"\\u5165\\u308b\\u30fb\\u306f\\u3044\\u308b\\u30fb1\"], \"ant\": [], \"field_\": [], \"misc\": [], \"s_inf\": \"mainly used in fixed expressions and literary language\", \"lsource\": [], \"dial\": [], \"gloss\": [{\"text\": \"to enter\", \"lang\": \"eng\", \"id\": 0}, {\"text\": \"to go in\", \"lang\": \"eng\", \"id\": 0}, {\"text\": \"to get in\", \"lang\": \"eng\", \"id\": 0}, {\"text\": \"to come in\", \"lang\": \"eng\", \"id\": 0}], \"id\": 0}, {\"stagk\": [], \"stagr\": [], \"pos\": [\"Godan verb with 'ru' ending\", \"intransitive verb\"], \"xref\": [], \"ant\": [], \"field_\": [], \"misc\": [], \"s_inf\": null, \"lsource\": [], \"dial\": [], \"gloss\": [{\"text\": \"to set (of the sun or moon)\", \"lang\": \"eng\", \"id\": 0}, {\"text\": \"to sink\", \"lang\": \"eng\", \"id\": 0}, {\"text\": \"to go down\", \"lang\": \"eng\", \"id\": 0}], \"id\": 0}, {\"stagk\": [], \"stagr\": [], \"pos\": [\"Godan verb with 'ru' ending\", \"intransitive verb\"], \"xref\": [], \"ant\": [], \"field_\": [], \"misc\": [], \"s_inf\": null, \"lsource\": [], \"dial\": [], \"gloss\": [{\"text\": \"to attain (nirvana, enlightenment, etc.)\", \"lang\": \"eng\", \"id\": 0}, {\"text\": \"to achieve\", \"lang\": \"eng\", \"id\": 0}, {\"text\": \"to reach (e.g. a climax)\", \"lang\": \"eng\", \"id\": 0}], \"id\": 0}, {\"stagk\": [], \"stagr\": [], \"pos\": [\"suffix\", \"Godan verb with 'ru' ending\"], \"xref\": [\"\\u611f\\u3058\\u5165\\u308b\", \"\\u805e\\u304d\\u5165\\u308b\"], \"ant\": [], \"field_\": [], \"misc\": [], \"s_inf\": \"after -masu stem of verb\", \"lsource\": [], \"dial\": [], \"gloss\": [{\"text\": \"to do fully\", \"lang\": \"eng\", \"id\": 0}, {\"text\": \"to do intently\", \"lang\": \"eng\", \"id\": 0}, {\"text\": \"to do sincerely\", \"lang\": \"eng\", \"id\": 0}, {\"text\": \"to do deeply\", \"lang\": \"eng\", \"id\": 0}, {\"text\": \"to feel keenly\", \"lang\": \"eng\", \"id\": 0}], \"id\": 0}, {\"stagk\": [], \"stagr\": [], \"pos\": [\"suffix\", \"Godan verb with 'ru' ending\"], \"xref\": [\"\\u5bdd\\u5165\\u308b\\u30fb1\", \"\\u7d76\\u3048\\u5165\\u308b\"], \"ant\": [], \"field_\": [], \"misc\": [], \"s_inf\": \"after -masu stem of verb\", \"lsource\": [], \"dial\": [], \"gloss\": [{\"text\": \"to (reach a state) completely\", \"lang\": \"eng\", \"id\": 0}], \"id\": 0}], \"id\": 0}, \"annotator_id\": \"default\", \"document_id\": \"c500bfb4-3069-4f0b-80e0-2e13a33366a6\", \"created\": \"2025/03/29 08:28:18.454754\", \"target\": {\"selector\": [{\"startContainer\": \"/\", \"endContainer\": \"/\", \"startOffset\": 3, \"endOffset\": 5}], \"source\": null}}, {\"id\": \"853eb495-0169-4844-8c0d-b07c76392cf9\", \"task_id\": \"default\", \"entity_id\": \"default\", \"body\": {\"ent_seq\": \"2423330\", \"k_ele\": [{\"keb\": \"\\u571f\", \"ke_inf\": [], \"ke_pri\": [], \"id\": 0}], \"r_ele\": [{\"reb\": \"\\u306b\", \"re_nokanji\": false, \"re_restr\": [], \"re_inf\": [], \"re_pri\": [], \"id\": 0}], \"sense\": [{\"stagk\": [], \"stagr\": [], \"pos\": [\"noun (common) (futsuumeishi)\"], \"xref\": [], \"ant\": [], \"field_\": [], \"misc\": [\"archaic\"], \"s_inf\": null, \"lsource\": [], \"dial\": [], \"gloss\": [{\"text\": \"soil (esp. reddish soil)\", \"lang\": \"eng\", \"id\": 0}], \"id\": 0}], \"id\": 0}, \"annotator_id\": \"default\", \"document_id\": \"c500bfb4-3069-4f0b-80e0-2e13a33366a6\", \"created\": \"2025/03/29 08:28:18.454251\", \"target\": {\"selector\": [{\"startContainer\": \"/\", \"endContainer\": \"/\", \"startOffset\": 2, \"endOffset\": 3}], \"source\": null}}, {\"id\": \"a3e3380b-0472-4c2f-b5a9-5c4d297da197\", \"task_id\": \"default\", \"entity_id\": \"default\", \"body\": {\"ent_seq\": \"2829645\", \"k_ele\": [], \"r_ele\": [{\"reb\": \"\\u305a\", \"re_nokanji\": false, \"re_restr\": [], \"re_inf\": [], \"re_pri\": [], \"id\": 0}], \"sense\": [{\"stagk\": [], \"stagr\": [], \"pos\": [\"auxiliary verb\", \"suffix\"], \"xref\": [\"\\u306c\"], \"ant\": [], \"field_\": [], \"misc\": [], \"s_inf\": \"after the -nai stem of a verb\", \"lsource\": [], \"dial\": [], \"gloss\": [{\"text\": \"not doing\", \"lang\": \"eng\", \"id\": 0}], \"id\": 0}], \"id\": 0}, \"annotator_id\": \"default\", \"document_id\": \"c500bfb4-3069-4f0b-80e0-2e13a33366a6\", \"created\": \"2025/03/29 08:28:18.455561\", \"target\": {\"selector\": [{\"startContainer\": \"/\", \"endContainer\": \"/\", \"startOffset\": 6, \"endOffset\": 7}], \"source\": null}}, {\"id\": \"99ee5cc2-9ba6-4cda-b82a-3d15dff2b2f8\", \"task_id\": \"default\", \"entity_id\": \"default\", \"body\": {\"ent_seq\": \"1607320\", \"k_ele\": [{\"keb\": \"\\u628a\", \"ke_inf\": [], \"ke_pri\": [\"ichi1\", \"news2\", \"nf39\"], \"id\": 0}], \"r_ele\": [{\"reb\": \"\\u308f\", \"re_nokanji\": false, \"re_restr\": [], \"re_inf\": [], \"re_pri\": [\"ichi1\", \"news2\", \"nf39\"], \"id\": 0}, {\"reb\": \"\\u3070\", \"re_nokanji\": false, \"re_restr\": [], \"re_inf\": [], \"re_pri\": [], \"id\": 0}, {\"reb\": \"\\u3071\", \"re_nokanji\": false, \"re_restr\": [], \"re_inf\": [], \"re_pri\": [], \"id\": 0}], \"sense\": [{\"stagk\": [], \"stagr\": [], \"pos\": [\"counter\"], \"xref\": [], \"ant\": [], \"field_\": [], \"misc\": [], \"s_inf\": null, \"lsource\": [], \"dial\": [], \"gloss\": [{\"text\": \"counter for bundles\", \"lang\": \"eng\", \"id\": 0}], \"id\": 0}], \"id\": 0}, \"annotator_id\": \"default\", \"document_id\": \"c500bfb4-3069-4f0b-80e0-2e13a33366a6\", \"created\": \"2025/03/29 08:28:18.456072\", \"target\": {\"selector\": [{\"startContainer\": \"/\", \"endContainer\": \"/\", \"startOffset\": 7, \"endOffset\": 8}], \"source\": null}}, {\"id\": \"55a77a78-76c0-4e37-a037-071b4fb56315\", \"task_id\": \"default\", \"entity_id\": \"default\", \"body\": {\"ent_seq\": \"2829645\", \"k_ele\": [], \"r_ele\": [{\"reb\": \"\\u305a\", \"re_nokanji\": false, \"re_restr\": [], \"re_inf\": [], \"re_pri\": [], \"id\": 0}], \"sense\": [{\"stagk\": [], \"stagr\": [], \"pos\": [\"auxiliary verb\", \"suffix\"], \"xref\": [\"\\u306c\"], \"ant\": [], \"field_\": [], \"misc\": [], \"s_inf\": \"after the -nai stem of a verb\", \"lsource\": [], \"dial\": [], \"gloss\": [{\"text\": \"not doing\", \"lang\": \"eng\", \"id\": 0}], \"id\": 0}], \"id\": 0}, \"annotator_id\": \"default\", \"document_id\": \"c500bfb4-3069-4f0b-80e0-2e13a33366a6\", \"created\": \"2025/03/29 08:28:18.457363\", \"target\": {\"selector\": [{\"startContainer\": \"/\", \"endContainer\": \"/\", \"startOffset\": 12, \"endOffset\": 13}], \"source\": null}}, {\"id\": \"d43ae216-cabf-4cd8-9c54-5db1dc68fdb7\", \"task_id\": \"default\", \"entity_id\": \"default\", \"body\": {\"ent_seq\": \"1267670\", \"k_ele\": [{\"keb\": \"\\u864e\\u7a74\", \"ke_inf\": [], \"ke_pri\": [], \"id\": 0}], \"r_ele\": [{\"reb\": \"\\u3053\\u3051\\u3064\", \"re_nokanji\": false, \"re_restr\": [], \"re_inf\": [], \"re_pri\": [], \"id\": 0}], \"sense\": [{\"stagk\": [], \"stagr\": [], \"pos\": [\"noun (common) (futsuumeishi)\"], \"xref\": [], \"ant\": [], \"field_\": [], \"misc\": [], \"s_inf\": null, \"lsource\": [], \"dial\": [], \"gloss\": [{\"text\": \"lion's den\", \"lang\": \"eng\", \"id\": 0}, {\"text\": \"very dangerous place or situation\", \"lang\": \"eng\", \"id\": 0}, {\"text\": \"tiger's den\", \"lang\": \"eng\", \"id\": 0}], \"id\": 0}], \"id\": 0}, \"annotator_id\": \"default\", \"document_id\": \"c500bfb4-3069-4f0b-80e0-2e13a33366a6\", \"created\": \"2025/03/29 08:28:18.453687\", \"target\": {\"selector\": [{\"startContainer\": \"/\", \"endContainer\": \"/\", \"startOffset\": 0, \"endOffset\": 2}], \"source\": null}}, {\"id\": \"369992f9-0d83-44bc-9ee1-87b5bb7a33c5\", \"task_id\": \"default\", \"entity_id\": \"default\", \"body\": {\"ent_seq\": \"2270780\", \"k_ele\": [{\"keb\": \"\\u864e\\u5150\", \"ke_inf\": [], \"ke_pri\": [], \"id\": 0}], \"r_ele\": [{\"reb\": \"\\u3053\\u3058\", \"re_nokanji\": false, \"re_restr\": [], \"re_inf\": [], \"re_pri\": [], \"id\": 0}], \"sense\": [{\"stagk\": [], \"stagr\": [], \"pos\": [\"noun (common) (futsuumeishi)\"], \"xref\": [], \"ant\": [], \"field_\": [], \"misc\": [], \"s_inf\": null, \"lsource\": [], \"dial\": [], \"gloss\": [{\"text\": \"tiger cub\", \"lang\": \"eng\", \"id\": 0}], \"id\": 0}], \"id\": 0}, \"annotator_id\": \"default\", \"document_id\": \"c500bfb4-3069-4f0b-80e0-2e13a33366a6\", \"created\": \"2025/03/29 08:28:18.456359\", \"target\": {\"selector\": [{\"startContainer\": \"/\", \"endContainer\": \"/\", \"startOffset\": 8, \"endOffset\": 10}], \"source\": null}}, {\"id\": \"54e00da0-a676-47a3-a330-641ec83cd20e\", \"task_id\": \"default\", \"entity_id\": \"default\", \"body\": {\"ent_seq\": \"2029010\", \"k_ele\": [], \"r_ele\": [{\"reb\": \"\\u3092\", \"re_nokanji\": false, \"re_restr\": [], \"re_inf\": [], \"re_pri\": [\"spec1\"], \"id\": 0}], \"sense\": [{\"stagk\": [], \"stagr\": [], \"pos\": [\"particle\"], \"xref\": [], \"ant\": [], \"field_\": [], \"misc\": [], \"s_inf\": null, \"lsource\": [], \"dial\": [], \"gloss\": [{\"text\": \"indicates direct object of action\", \"lang\": \"eng\", \"id\": 0}], \"id\": 0}, {\"stagk\": [], \"stagr\": [], \"pos\": [\"particle\"], \"xref\": [], \"ant\": [], \"field_\": [], \"misc\": [], \"s_inf\": null, \"lsource\": [], \"dial\": [], \"gloss\": [{\"text\": \"indicates subject of causative expression\", \"lang\": \"eng\", \"id\": 0}], \"id\": 0}, {\"stagk\": [], \"stagr\": [], \"pos\": [\"particle\"], \"xref\": [], \"ant\": [], \"field_\": [], \"misc\": [], \"s_inf\": null, \"lsource\": [], \"dial\": [], \"gloss\": [{\"text\": \"indicates an area traversed\", \"lang\": \"eng\", \"id\": 0}], \"id\": 0}, {\"stagk\": [], \"stagr\": [], \"pos\": [\"particle\"], \"xref\": [], \"ant\": [], \"field_\": [], \"misc\": [], \"s_inf\": null, \"lsource\": [], \"dial\": [], \"gloss\": [{\"text\": \"indicates time (period) over which action takes place\", \"lang\": \"eng\", \"id\": 0}], \"id\": 0}, {\"stagk\": [], \"stagr\": [], \"pos\": [\"particle\"], \"xref\": [], \"ant\": [], \"field_\": [], \"misc\": [], \"s_inf\": null, \"lsource\": [], \"dial\": [], \"gloss\": [{\"text\": \"indicates point of departure or separation of action\", \"lang\": \"eng\", \"id\": 0}], \"id\": 0}, {\"stagk\": [], \"stagr\": [], \"pos\": [\"particle\"], \"xref\": [\"\\u304c\\u30fb1\"], \"ant\": [], \"field_\": [], \"misc\": [], \"s_inf\": null, \"lsource\": [], \"dial\": [], \"gloss\": [{\"text\": \"indicates object of desire, like, hate, etc.\", \"lang\": \"eng\", \"id\": 0}], \"id\": 0}], \"id\": 0}, \"annotator_id\": \"default\", \"document_id\": \"c500bfb4-3069-4f0b-80e0-2e13a33366a6\", \"created\": \"2025/03/29 08:28:18.456744\", \"target\": {\"selector\": [{\"startContainer\": \"/\", \"endContainer\": \"/\", \"startOffset\": 10, \"endOffset\": 11}], \"source\": null}}, {\"id\": \"a0aefdb6-d88e-4bfe-8556-55bed1261d7b\", \"task_id\": \"default\", \"entity_id\": \"default\", \"body\": {\"ent_seq\": \"2829645\", \"k_ele\": [], \"r_ele\": [{\"reb\": \"\\u305a\", \"re_nokanji\": false, \"re_restr\": [], \"re_inf\": [], \"re_pri\": [], \"id\": 0}], \"sense\": [{\"stagk\": [], \"stagr\": [], \"pos\": [\"auxiliary verb\", \"suffix\"], \"xref\": [\"\\u306c\"], \"ant\": [], \"field_\": [], \"misc\": [], \"s_inf\": \"after the -nai stem of a verb\", \"lsource\": [], \"dial\": [], \"gloss\": [{\"text\": \"not doing\", \"lang\": \"eng\", \"id\": 0}], \"id\": 0}], \"id\": 0}, \"annotator_id\": \"default\", \"document_id\": \"c500bfb4-3069-4f0b-80e0-2e13a33366a6\", \"created\": \"2025/03/29 08:28:18.455180\", \"target\": {\"selector\": [{\"startContainer\": \"/\", \"endContainer\": \"/\", \"startOffset\": 5, \"endOffset\": 6}], \"source\": null}}, {\"id\": \"ea5ffa51-d90a-409c-9373-d3f452db2199\", \"task_id\": \"default\", \"entity_id\": \"default\", \"body\": {\"ent_seq\": \"1588760\", \"k_ele\": [{\"keb\": \"\\u5f97\\u308b\", \"ke_inf\": [], \"ke_pri\": [\"ichi1\"], \"id\": 0}, {\"keb\": \"\\u7372\\u308b\", \"ke_inf\": [], \"ke_pri\": [], \"id\": 0}], \"r_ele\": [{\"reb\": \"\\u3048\\u308b\", \"re_nokanji\": false, \"re_restr\": [], \"re_inf\": [], \"re_pri\": [\"ichi1\"], \"id\": 0}], \"sense\": [{\"stagk\": [], \"stagr\": [], \"pos\": [\"Ichidan verb\", \"transitive verb\"], \"xref\": [], \"ant\": [], \"field_\": [], \"misc\": [], \"s_inf\": \"\\u7372\\u308b esp. refers to catching wild game, etc.\", \"lsource\": [], \"dial\": [], \"gloss\": [{\"text\": \"to get\", \"lang\": \"eng\", \"id\": 0}, {\"text\": \"to earn\", \"lang\": \"eng\", \"id\": 0}, {\"text\": \"to acquire\", \"lang\": \"eng\", \"id\": 0}, {\"text\": \"to procure\", \"lang\": \"eng\", \"id\": 0}, {\"text\": \"to gain\", \"lang\": \"eng\", \"id\": 0}, {\"text\": \"to secure\", \"lang\": \"eng\", \"id\": 0}, {\"text\": \"to attain\", \"lang\": \"eng\", \"id\": 0}, {\"text\": \"to obtain\", \"lang\": \"eng\", \"id\": 0}, {\"text\": \"to win\", \"lang\": \"eng\", \"id\": 0}], \"id\": 0}, {\"stagk\": [], \"stagr\": [], \"pos\": [\"Ichidan verb\", \"transitive verb\"], \"xref\": [], \"ant\": [], \"field_\": [], \"misc\": [], \"s_inf\": null, \"lsource\": [], \"dial\": [], \"gloss\": [{\"text\": \"to understand\", \"lang\": \"eng\", \"id\": 0}, {\"text\": \"to comprehend\", \"lang\": \"eng\", \"id\": 0}], \"id\": 0}, {\"stagk\": [], \"stagr\": [], \"pos\": [\"Ichidan verb\", \"transitive verb\"], \"xref\": [], \"ant\": [], \"field_\": [], \"misc\": [], \"s_inf\": null, \"lsource\": [], \"dial\": [], \"gloss\": [{\"text\": \"to receive something undesirable (e.g. a punishment)\", \"lang\": \"eng\", \"id\": 0}, {\"text\": \"to get (ill)\", \"lang\": \"eng\", \"id\": 0}], \"id\": 0}, {\"stagk\": [\"\\u5f97\\u308b\"], \"stagr\": [], \"pos\": [\"auxiliary verb\", \"Ichidan verb\", \"transitive verb\"], \"xref\": [\"\\u5f97\\u306a\\u3044\", \"\\u5f97\\u308b\\u30fb\\u3046\\u308b\\u30fb1\"], \"ant\": [], \"field_\": [], \"misc\": [], \"s_inf\": \"after the -masu stem of a verb\", \"lsource\": [], \"dial\": [], \"gloss\": [{\"text\": \"to be able to ..., can ...\", \"lang\": \"eng\", \"id\": 0}], \"id\": 0}], \"id\": 0}, \"annotator_id\": \"default\", \"document_id\": \"c500bfb4-3069-4f0b-80e0-2e13a33366a6\", \"created\": \"2025/03/29 08:28:18.457255\", \"target\": {\"selector\": [{\"startContainer\": \"/\", \"endContainer\": \"/\", \"startOffset\": 11, \"endOffset\": 12}], \"source\": null}}]);\n",
+       "</script>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "display(doc, height=\"600px\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[Entry(ent_seq='1212250', k_ele=[Kanji(keb='感じ', ke_inf=[], ke_pri=['ichi1', 'news1', 'nf02'], id=0)], r_ele=[Reading(reb='かんじ', re_nokanji=False, re_restr=[], re_inf=[], re_pri=['ichi1', 'news1', 'nf02'], id=0)], sense=[Sense(stagk=[], stagr=[], pos=['noun (common) (futsuumeishi)'], xref=[], ant=[], field_=[], misc=[], s_inf=None, lsource=[], dial=[], gloss=[Gloss(text='feeling', lang='eng', id=0), Gloss(text='sense', lang='eng', id=0), Gloss(text='impression', lang='eng', id=0)], id=0)], id=0)]"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "jmdict.search('感じ')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataclasses import asdict"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'ent_seq': '1212250',\n",
+       " 'k_ele': [{'keb': '感じ',\n",
+       "   'ke_inf': [],\n",
+       "   'ke_pri': ['ichi1', 'news1', 'nf02'],\n",
+       "   'id': 0}],\n",
+       " 'r_ele': [{'reb': 'かんじ',\n",
+       "   're_nokanji': False,\n",
+       "   're_restr': [],\n",
+       "   're_inf': [],\n",
+       "   're_pri': ['ichi1', 'news1', 'nf02'],\n",
+       "   'id': 0}],\n",
+       " 'sense': [{'stagk': [],\n",
+       "   'stagr': [],\n",
+       "   'pos': ['noun (common) (futsuumeishi)'],\n",
+       "   'xref': [],\n",
+       "   'ant': [],\n",
+       "   'field_': [],\n",
+       "   'misc': [],\n",
+       "   's_inf': None,\n",
+       "   'lsource': [],\n",
+       "   'dial': [],\n",
+       "   'gloss': [{'text': 'feeling', 'lang': 'eng', 'id': 0},\n",
+       "    {'text': 'sense', 'lang': 'eng', 'id': 0},\n",
+       "    {'text': 'impression', 'lang': 'eng', 'id': 0}],\n",
+       "   'id': 0}],\n",
+       " 'id': 0}"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "asdict(jmdict.feeling_lucky('感じ'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/vizualize.ipynb
+++ b/examples/vizualize.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -12,129 +12,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "<style>\n",
-       "    .underline {\n",
-       "        border-bottom: 1px dotted grey;\n",
-       "        cursor: pointer;\n",
-       "        margin-right: 3px;\n",
-       "    }\n",
-       "    .tooltip {\n",
-       "        white-space: pre;\n",
-       "        display: none;\n",
-       "        background: black;\n",
-       "        color: white;\n",
-       "        padding: 4px 8px;\n",
-       "        font-size: 13px;\n",
-       "        border-radius: 4px;\n",
-       "        max-width: 400px;\n",
-       "        text-wrap: wrap;\n",
-       "    }\n",
-       "\n",
-       "    .tooltip[data-show] {\n",
-       "        display: block;\n",
-       "    }\n",
-       "    .arrow,\n",
-       "    .arrow::before {\n",
-       "        position: absolute;\n",
-       "        width: 8px;\n",
-       "        height: 8px;\n",
-       "        background: inherit;\n",
-       "    }\n",
-       "\n",
-       "    .arrow {\n",
-       "        visibility: hidden;\n",
-       "    }\n",
-       "\n",
-       "    .arrow::before {\n",
-       "        visibility: visible;\n",
-       "        content: '';\n",
-       "        transform: rotate(45deg);\n",
-       "    }\n",
-       "    .tooltip[data-popper-placement^='top'] > .arrow {\n",
-       "        bottom: -4px;\n",
-       "    }\n",
-       "\n",
-       "    .tooltip[data-popper-placement^='bottom'] > .arrow {\n",
-       "        top: -4px;\n",
-       "    }\n",
-       "\n",
-       "    .tooltip[data-popper-placement^='left'] > .arrow {\n",
-       "        right: -4px;\n",
-       "    }\n",
-       "\n",
-       "    .tooltip[data-popper-placement^='right'] > .arrow {\n",
-       "        left: -4px;\n",
-       "    }\n",
-       "</style>\n",
-       "<script type=\"text/javascript\" src=\"https://storage.googleapis.com/linhub.linalgo.com/linalgo.2.umd.js\"></script>\n",
-       "<script src=\"https://unpkg.com/@popperjs/core@2\"></script>\n",
-       "<script type=\"text/javascript\">\n",
-       "function annotate(selector, annotations) {\n",
-       "    const Annotator = window[\"@linalgo/annotate-core\"].Annotator\n",
-       "    const doc = document.querySelector(`[id='${selector}']`);\n",
-       "    const annotator = new Annotator(doc);\n",
-       "    for (annotation of annotations) {\n",
-       "        annotator.showAnnotation(annotation);\n",
-       "        const elements = document.querySelectorAll(`[id='${annotation.id}']`);\n",
-       "        elements.forEach(el => {\n",
-       "            el.classList.add(\"underline\");\n",
-       "            if (!el.textContent) {\n",
-       "                el.remove()\n",
-       "            }\n",
-       "        });\n",
-       "        const node = document.createElement(\"div\");\n",
-       "        const textnode = document.createTextNode(JSON.stringify(annotation.body, null, 2));\n",
-       "        const arrow = document.createElement(\"div\");\n",
-       "        node.setAttribute(\"role\", \"tooltip\");\n",
-       "        node.classList.add(\"tooltip\");\n",
-       "        arrow.setAttribute(\"data-popper-arrow\", \"\");\n",
-       "        arrow.classList.add(\"arrow\");\n",
-       "        doc.appendChild(node);\n",
-       "        node.appendChild(textnode);\n",
-       "        node.appendChild(arrow);\n",
-       "        elements.forEach(el => {\n",
-       "            const popperInstance = Popper.createPopper(el, node, {\n",
-       "                placement: 'bottom',\n",
-       "                modifiers: [\n",
-       "                    {\n",
-       "                        name: 'offset',\n",
-       "                        options: {\n",
-       "                            offset: [0, 8],\n",
-       "                        },\n",
-       "                    },\n",
-       "                ],\n",
-       "            })\n",
-       "            function show() {\n",
-       "                if (node.hasAttribute('data-show')) {\n",
-       "                    node.removeAttribute('data-show');\n",
-       "                } else {\n",
-       "                    node.setAttribute('data-show', '');\n",
-       "                }\n",
-       "                popperInstance.update();\n",
-       "            }\n",
-       "            el.addEventListener('click', show)\n",
-       "        });\n",
-       "    }\n",
-       "}\n",
-       "</script>\n",
-       "<div style=\"font-style: italic;\">Success!</div>\n"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from linalgo.annotate import Document, Annotation\n",
     "from linalgo.annotate.display import init, display\n",
@@ -146,25 +26,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 6.54 s, sys: 174 ms, total: 6.71 s\n",
-      "Wall time: 6.74 s\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "jmdict = JMDict()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -174,53 +45,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div id='97f40785079e44368386947e1f6cdf52' class='doc' style='min-height: 600px'>虎穴に入らずんば虎子を得ず</div>\n",
-       "<script type=\"text/javascript\">\n",
-       "  annotate('97f40785079e44368386947e1f6cdf52', [{\"id\": \"80b12f76-48e5-4a7f-ac68-01eafc82bab4\", \"task_id\": \"default\", \"entity_id\": \"default\", \"body\": {\"ent_seq\": \"1465580\", \"k_ele\": [{\"keb\": \"\\u5165\\u308b\", \"ke_inf\": [], \"ke_pri\": [\"ichi1\"], \"id\": 0}], \"r_ele\": [{\"reb\": \"\\u3044\\u308b\", \"re_nokanji\": false, \"re_restr\": [], \"re_inf\": [], \"re_pri\": [\"ichi1\"], \"id\": 0}], \"sense\": [{\"stagk\": [], \"stagr\": [], \"pos\": [\"Godan verb with 'ru' ending\", \"intransitive verb\"], \"xref\": [\"\\u5165\\u308b\\u30fb\\u306f\\u3044\\u308b\\u30fb1\"], \"ant\": [], \"field_\": [], \"misc\": [], \"s_inf\": \"mainly used in fixed expressions and literary language\", \"lsource\": [], \"dial\": [], \"gloss\": [{\"text\": \"to enter\", \"lang\": \"eng\", \"id\": 0}, {\"text\": \"to go in\", \"lang\": \"eng\", \"id\": 0}, {\"text\": \"to get in\", \"lang\": \"eng\", \"id\": 0}, {\"text\": \"to come in\", \"lang\": \"eng\", \"id\": 0}], \"id\": 0}, {\"stagk\": [], \"stagr\": [], \"pos\": [\"Godan verb with 'ru' ending\", \"intransitive verb\"], \"xref\": [], \"ant\": [], \"field_\": [], \"misc\": [], \"s_inf\": null, \"lsource\": [], \"dial\": [], \"gloss\": [{\"text\": \"to set (of the sun or moon)\", \"lang\": \"eng\", \"id\": 0}, {\"text\": \"to sink\", \"lang\": \"eng\", \"id\": 0}, {\"text\": \"to go down\", \"lang\": \"eng\", \"id\": 0}], \"id\": 0}, {\"stagk\": [], \"stagr\": [], \"pos\": [\"Godan verb with 'ru' ending\", \"intransitive verb\"], \"xref\": [], \"ant\": [], \"field_\": [], \"misc\": [], \"s_inf\": null, \"lsource\": [], \"dial\": [], \"gloss\": [{\"text\": \"to attain (nirvana, enlightenment, etc.)\", \"lang\": \"eng\", \"id\": 0}, {\"text\": \"to achieve\", \"lang\": \"eng\", \"id\": 0}, {\"text\": \"to reach (e.g. a climax)\", \"lang\": \"eng\", \"id\": 0}], \"id\": 0}, {\"stagk\": [], \"stagr\": [], \"pos\": [\"suffix\", \"Godan verb with 'ru' ending\"], \"xref\": [\"\\u611f\\u3058\\u5165\\u308b\", \"\\u805e\\u304d\\u5165\\u308b\"], \"ant\": [], \"field_\": [], \"misc\": [], \"s_inf\": \"after -masu stem of verb\", \"lsource\": [], \"dial\": [], \"gloss\": [{\"text\": \"to do fully\", \"lang\": \"eng\", \"id\": 0}, {\"text\": \"to do intently\", \"lang\": \"eng\", \"id\": 0}, {\"text\": \"to do sincerely\", \"lang\": \"eng\", \"id\": 0}, {\"text\": \"to do deeply\", \"lang\": \"eng\", \"id\": 0}, {\"text\": \"to feel keenly\", \"lang\": \"eng\", \"id\": 0}], \"id\": 0}, {\"stagk\": [], \"stagr\": [], \"pos\": [\"suffix\", \"Godan verb with 'ru' ending\"], \"xref\": [\"\\u5bdd\\u5165\\u308b\\u30fb1\", \"\\u7d76\\u3048\\u5165\\u308b\"], \"ant\": [], \"field_\": [], \"misc\": [], \"s_inf\": \"after -masu stem of verb\", \"lsource\": [], \"dial\": [], \"gloss\": [{\"text\": \"to (reach a state) completely\", \"lang\": \"eng\", \"id\": 0}], \"id\": 0}], \"id\": 0}, \"annotator_id\": \"default\", \"document_id\": \"c500bfb4-3069-4f0b-80e0-2e13a33366a6\", \"created\": \"2025/03/29 08:28:18.454754\", \"target\": {\"selector\": [{\"startContainer\": \"/\", \"endContainer\": \"/\", \"startOffset\": 3, \"endOffset\": 5}], \"source\": null}}, {\"id\": \"853eb495-0169-4844-8c0d-b07c76392cf9\", \"task_id\": \"default\", \"entity_id\": \"default\", \"body\": {\"ent_seq\": \"2423330\", \"k_ele\": [{\"keb\": \"\\u571f\", \"ke_inf\": [], \"ke_pri\": [], \"id\": 0}], \"r_ele\": [{\"reb\": \"\\u306b\", \"re_nokanji\": false, \"re_restr\": [], \"re_inf\": [], \"re_pri\": [], \"id\": 0}], \"sense\": [{\"stagk\": [], \"stagr\": [], \"pos\": [\"noun (common) (futsuumeishi)\"], \"xref\": [], \"ant\": [], \"field_\": [], \"misc\": [\"archaic\"], \"s_inf\": null, \"lsource\": [], \"dial\": [], \"gloss\": [{\"text\": \"soil (esp. reddish soil)\", \"lang\": \"eng\", \"id\": 0}], \"id\": 0}], \"id\": 0}, \"annotator_id\": \"default\", \"document_id\": \"c500bfb4-3069-4f0b-80e0-2e13a33366a6\", \"created\": \"2025/03/29 08:28:18.454251\", \"target\": {\"selector\": [{\"startContainer\": \"/\", \"endContainer\": \"/\", \"startOffset\": 2, \"endOffset\": 3}], \"source\": null}}, {\"id\": \"a3e3380b-0472-4c2f-b5a9-5c4d297da197\", \"task_id\": \"default\", \"entity_id\": \"default\", \"body\": {\"ent_seq\": \"2829645\", \"k_ele\": [], \"r_ele\": [{\"reb\": \"\\u305a\", \"re_nokanji\": false, \"re_restr\": [], \"re_inf\": [], \"re_pri\": [], \"id\": 0}], \"sense\": [{\"stagk\": [], \"stagr\": [], \"pos\": [\"auxiliary verb\", \"suffix\"], \"xref\": [\"\\u306c\"], \"ant\": [], \"field_\": [], \"misc\": [], \"s_inf\": \"after the -nai stem of a verb\", \"lsource\": [], \"dial\": [], \"gloss\": [{\"text\": \"not doing\", \"lang\": \"eng\", \"id\": 0}], \"id\": 0}], \"id\": 0}, \"annotator_id\": \"default\", \"document_id\": \"c500bfb4-3069-4f0b-80e0-2e13a33366a6\", \"created\": \"2025/03/29 08:28:18.455561\", \"target\": {\"selector\": [{\"startContainer\": \"/\", \"endContainer\": \"/\", \"startOffset\": 6, \"endOffset\": 7}], \"source\": null}}, {\"id\": \"99ee5cc2-9ba6-4cda-b82a-3d15dff2b2f8\", \"task_id\": \"default\", \"entity_id\": \"default\", \"body\": {\"ent_seq\": \"1607320\", \"k_ele\": [{\"keb\": \"\\u628a\", \"ke_inf\": [], \"ke_pri\": [\"ichi1\", \"news2\", \"nf39\"], \"id\": 0}], \"r_ele\": [{\"reb\": \"\\u308f\", \"re_nokanji\": false, \"re_restr\": [], \"re_inf\": [], \"re_pri\": [\"ichi1\", \"news2\", \"nf39\"], \"id\": 0}, {\"reb\": \"\\u3070\", \"re_nokanji\": false, \"re_restr\": [], \"re_inf\": [], \"re_pri\": [], \"id\": 0}, {\"reb\": \"\\u3071\", \"re_nokanji\": false, \"re_restr\": [], \"re_inf\": [], \"re_pri\": [], \"id\": 0}], \"sense\": [{\"stagk\": [], \"stagr\": [], \"pos\": [\"counter\"], \"xref\": [], \"ant\": [], \"field_\": [], \"misc\": [], \"s_inf\": null, \"lsource\": [], \"dial\": [], \"gloss\": [{\"text\": \"counter for bundles\", \"lang\": \"eng\", \"id\": 0}], \"id\": 0}], \"id\": 0}, \"annotator_id\": \"default\", \"document_id\": \"c500bfb4-3069-4f0b-80e0-2e13a33366a6\", \"created\": \"2025/03/29 08:28:18.456072\", \"target\": {\"selector\": [{\"startContainer\": \"/\", \"endContainer\": \"/\", \"startOffset\": 7, \"endOffset\": 8}], \"source\": null}}, {\"id\": \"55a77a78-76c0-4e37-a037-071b4fb56315\", \"task_id\": \"default\", \"entity_id\": \"default\", \"body\": {\"ent_seq\": \"2829645\", \"k_ele\": [], \"r_ele\": [{\"reb\": \"\\u305a\", \"re_nokanji\": false, \"re_restr\": [], \"re_inf\": [], \"re_pri\": [], \"id\": 0}], \"sense\": [{\"stagk\": [], \"stagr\": [], \"pos\": [\"auxiliary verb\", \"suffix\"], \"xref\": [\"\\u306c\"], \"ant\": [], \"field_\": [], \"misc\": [], \"s_inf\": \"after the -nai stem of a verb\", \"lsource\": [], \"dial\": [], \"gloss\": [{\"text\": \"not doing\", \"lang\": \"eng\", \"id\": 0}], \"id\": 0}], \"id\": 0}, \"annotator_id\": \"default\", \"document_id\": \"c500bfb4-3069-4f0b-80e0-2e13a33366a6\", \"created\": \"2025/03/29 08:28:18.457363\", \"target\": {\"selector\": [{\"startContainer\": \"/\", \"endContainer\": \"/\", \"startOffset\": 12, \"endOffset\": 13}], \"source\": null}}, {\"id\": \"d43ae216-cabf-4cd8-9c54-5db1dc68fdb7\", \"task_id\": \"default\", \"entity_id\": \"default\", \"body\": {\"ent_seq\": \"1267670\", \"k_ele\": [{\"keb\": \"\\u864e\\u7a74\", \"ke_inf\": [], \"ke_pri\": [], \"id\": 0}], \"r_ele\": [{\"reb\": \"\\u3053\\u3051\\u3064\", \"re_nokanji\": false, \"re_restr\": [], \"re_inf\": [], \"re_pri\": [], \"id\": 0}], \"sense\": [{\"stagk\": [], \"stagr\": [], \"pos\": [\"noun (common) (futsuumeishi)\"], \"xref\": [], \"ant\": [], \"field_\": [], \"misc\": [], \"s_inf\": null, \"lsource\": [], \"dial\": [], \"gloss\": [{\"text\": \"lion's den\", \"lang\": \"eng\", \"id\": 0}, {\"text\": \"very dangerous place or situation\", \"lang\": \"eng\", \"id\": 0}, {\"text\": \"tiger's den\", \"lang\": \"eng\", \"id\": 0}], \"id\": 0}], \"id\": 0}, \"annotator_id\": \"default\", \"document_id\": \"c500bfb4-3069-4f0b-80e0-2e13a33366a6\", \"created\": \"2025/03/29 08:28:18.453687\", \"target\": {\"selector\": [{\"startContainer\": \"/\", \"endContainer\": \"/\", \"startOffset\": 0, \"endOffset\": 2}], \"source\": null}}, {\"id\": \"369992f9-0d83-44bc-9ee1-87b5bb7a33c5\", \"task_id\": \"default\", \"entity_id\": \"default\", \"body\": {\"ent_seq\": \"2270780\", \"k_ele\": [{\"keb\": \"\\u864e\\u5150\", \"ke_inf\": [], \"ke_pri\": [], \"id\": 0}], \"r_ele\": [{\"reb\": \"\\u3053\\u3058\", \"re_nokanji\": false, \"re_restr\": [], \"re_inf\": [], \"re_pri\": [], \"id\": 0}], \"sense\": [{\"stagk\": [], \"stagr\": [], \"pos\": [\"noun (common) (futsuumeishi)\"], \"xref\": [], \"ant\": [], \"field_\": [], \"misc\": [], \"s_inf\": null, \"lsource\": [], \"dial\": [], \"gloss\": [{\"text\": \"tiger cub\", \"lang\": \"eng\", \"id\": 0}], \"id\": 0}], \"id\": 0}, \"annotator_id\": \"default\", \"document_id\": \"c500bfb4-3069-4f0b-80e0-2e13a33366a6\", \"created\": \"2025/03/29 08:28:18.456359\", \"target\": {\"selector\": [{\"startContainer\": \"/\", \"endContainer\": \"/\", \"startOffset\": 8, \"endOffset\": 10}], \"source\": null}}, {\"id\": \"54e00da0-a676-47a3-a330-641ec83cd20e\", \"task_id\": \"default\", \"entity_id\": \"default\", \"body\": {\"ent_seq\": \"2029010\", \"k_ele\": [], \"r_ele\": [{\"reb\": \"\\u3092\", \"re_nokanji\": false, \"re_restr\": [], \"re_inf\": [], \"re_pri\": [\"spec1\"], \"id\": 0}], \"sense\": [{\"stagk\": [], \"stagr\": [], \"pos\": [\"particle\"], \"xref\": [], \"ant\": [], \"field_\": [], \"misc\": [], \"s_inf\": null, \"lsource\": [], \"dial\": [], \"gloss\": [{\"text\": \"indicates direct object of action\", \"lang\": \"eng\", \"id\": 0}], \"id\": 0}, {\"stagk\": [], \"stagr\": [], \"pos\": [\"particle\"], \"xref\": [], \"ant\": [], \"field_\": [], \"misc\": [], \"s_inf\": null, \"lsource\": [], \"dial\": [], \"gloss\": [{\"text\": \"indicates subject of causative expression\", \"lang\": \"eng\", \"id\": 0}], \"id\": 0}, {\"stagk\": [], \"stagr\": [], \"pos\": [\"particle\"], \"xref\": [], \"ant\": [], \"field_\": [], \"misc\": [], \"s_inf\": null, \"lsource\": [], \"dial\": [], \"gloss\": [{\"text\": \"indicates an area traversed\", \"lang\": \"eng\", \"id\": 0}], \"id\": 0}, {\"stagk\": [], \"stagr\": [], \"pos\": [\"particle\"], \"xref\": [], \"ant\": [], \"field_\": [], \"misc\": [], \"s_inf\": null, \"lsource\": [], \"dial\": [], \"gloss\": [{\"text\": \"indicates time (period) over which action takes place\", \"lang\": \"eng\", \"id\": 0}], \"id\": 0}, {\"stagk\": [], \"stagr\": [], \"pos\": [\"particle\"], \"xref\": [], \"ant\": [], \"field_\": [], \"misc\": [], \"s_inf\": null, \"lsource\": [], \"dial\": [], \"gloss\": [{\"text\": \"indicates point of departure or separation of action\", \"lang\": \"eng\", \"id\": 0}], \"id\": 0}, {\"stagk\": [], \"stagr\": [], \"pos\": [\"particle\"], \"xref\": [\"\\u304c\\u30fb1\"], \"ant\": [], \"field_\": [], \"misc\": [], \"s_inf\": null, \"lsource\": [], \"dial\": [], \"gloss\": [{\"text\": \"indicates object of desire, like, hate, etc.\", \"lang\": \"eng\", \"id\": 0}], \"id\": 0}], \"id\": 0}, \"annotator_id\": \"default\", \"document_id\": \"c500bfb4-3069-4f0b-80e0-2e13a33366a6\", \"created\": \"2025/03/29 08:28:18.456744\", \"target\": {\"selector\": [{\"startContainer\": \"/\", \"endContainer\": \"/\", \"startOffset\": 10, \"endOffset\": 11}], \"source\": null}}, {\"id\": \"a0aefdb6-d88e-4bfe-8556-55bed1261d7b\", \"task_id\": \"default\", \"entity_id\": \"default\", \"body\": {\"ent_seq\": \"2829645\", \"k_ele\": [], \"r_ele\": [{\"reb\": \"\\u305a\", \"re_nokanji\": false, \"re_restr\": [], \"re_inf\": [], \"re_pri\": [], \"id\": 0}], \"sense\": [{\"stagk\": [], \"stagr\": [], \"pos\": [\"auxiliary verb\", \"suffix\"], \"xref\": [\"\\u306c\"], \"ant\": [], \"field_\": [], \"misc\": [], \"s_inf\": \"after the -nai stem of a verb\", \"lsource\": [], \"dial\": [], \"gloss\": [{\"text\": \"not doing\", \"lang\": \"eng\", \"id\": 0}], \"id\": 0}], \"id\": 0}, \"annotator_id\": \"default\", \"document_id\": \"c500bfb4-3069-4f0b-80e0-2e13a33366a6\", \"created\": \"2025/03/29 08:28:18.455180\", \"target\": {\"selector\": [{\"startContainer\": \"/\", \"endContainer\": \"/\", \"startOffset\": 5, \"endOffset\": 6}], \"source\": null}}, {\"id\": \"ea5ffa51-d90a-409c-9373-d3f452db2199\", \"task_id\": \"default\", \"entity_id\": \"default\", \"body\": {\"ent_seq\": \"1588760\", \"k_ele\": [{\"keb\": \"\\u5f97\\u308b\", \"ke_inf\": [], \"ke_pri\": [\"ichi1\"], \"id\": 0}, {\"keb\": \"\\u7372\\u308b\", \"ke_inf\": [], \"ke_pri\": [], \"id\": 0}], \"r_ele\": [{\"reb\": \"\\u3048\\u308b\", \"re_nokanji\": false, \"re_restr\": [], \"re_inf\": [], \"re_pri\": [\"ichi1\"], \"id\": 0}], \"sense\": [{\"stagk\": [], \"stagr\": [], \"pos\": [\"Ichidan verb\", \"transitive verb\"], \"xref\": [], \"ant\": [], \"field_\": [], \"misc\": [], \"s_inf\": \"\\u7372\\u308b esp. refers to catching wild game, etc.\", \"lsource\": [], \"dial\": [], \"gloss\": [{\"text\": \"to get\", \"lang\": \"eng\", \"id\": 0}, {\"text\": \"to earn\", \"lang\": \"eng\", \"id\": 0}, {\"text\": \"to acquire\", \"lang\": \"eng\", \"id\": 0}, {\"text\": \"to procure\", \"lang\": \"eng\", \"id\": 0}, {\"text\": \"to gain\", \"lang\": \"eng\", \"id\": 0}, {\"text\": \"to secure\", \"lang\": \"eng\", \"id\": 0}, {\"text\": \"to attain\", \"lang\": \"eng\", \"id\": 0}, {\"text\": \"to obtain\", \"lang\": \"eng\", \"id\": 0}, {\"text\": \"to win\", \"lang\": \"eng\", \"id\": 0}], \"id\": 0}, {\"stagk\": [], \"stagr\": [], \"pos\": [\"Ichidan verb\", \"transitive verb\"], \"xref\": [], \"ant\": [], \"field_\": [], \"misc\": [], \"s_inf\": null, \"lsource\": [], \"dial\": [], \"gloss\": [{\"text\": \"to understand\", \"lang\": \"eng\", \"id\": 0}, {\"text\": \"to comprehend\", \"lang\": \"eng\", \"id\": 0}], \"id\": 0}, {\"stagk\": [], \"stagr\": [], \"pos\": [\"Ichidan verb\", \"transitive verb\"], \"xref\": [], \"ant\": [], \"field_\": [], \"misc\": [], \"s_inf\": null, \"lsource\": [], \"dial\": [], \"gloss\": [{\"text\": \"to receive something undesirable (e.g. a punishment)\", \"lang\": \"eng\", \"id\": 0}, {\"text\": \"to get (ill)\", \"lang\": \"eng\", \"id\": 0}], \"id\": 0}, {\"stagk\": [\"\\u5f97\\u308b\"], \"stagr\": [], \"pos\": [\"auxiliary verb\", \"Ichidan verb\", \"transitive verb\"], \"xref\": [\"\\u5f97\\u306a\\u3044\", \"\\u5f97\\u308b\\u30fb\\u3046\\u308b\\u30fb1\"], \"ant\": [], \"field_\": [], \"misc\": [], \"s_inf\": \"after the -masu stem of a verb\", \"lsource\": [], \"dial\": [], \"gloss\": [{\"text\": \"to be able to ..., can ...\", \"lang\": \"eng\", \"id\": 0}], \"id\": 0}], \"id\": 0}, \"annotator_id\": \"default\", \"document_id\": \"c500bfb4-3069-4f0b-80e0-2e13a33366a6\", \"created\": \"2025/03/29 08:28:18.457255\", \"target\": {\"selector\": [{\"startContainer\": \"/\", \"endContainer\": \"/\", \"startOffset\": 11, \"endOffset\": 12}], \"source\": null}}]);\n",
-       "</script>\n"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "display(doc, height=\"600px\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[Entry(ent_seq='1212250', k_ele=[Kanji(keb='感じ', ke_inf=[], ke_pri=['ichi1', 'news1', 'nf02'], id=0)], r_ele=[Reading(reb='かんじ', re_nokanji=False, re_restr=[], re_inf=[], re_pri=['ichi1', 'news1', 'nf02'], id=0)], sense=[Sense(stagk=[], stagr=[], pos=['noun (common) (futsuumeishi)'], xref=[], ant=[], field_=[], misc=[], s_inf=None, lsource=[], dial=[], gloss=[Gloss(text='feeling', lang='eng', id=0), Gloss(text='sense', lang='eng', id=0), Gloss(text='impression', lang='eng', id=0)], id=0)], id=0)]"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "jmdict.search('感じ')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -229,45 +72,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'ent_seq': '1212250',\n",
-       " 'k_ele': [{'keb': '感じ',\n",
-       "   'ke_inf': [],\n",
-       "   'ke_pri': ['ichi1', 'news1', 'nf02'],\n",
-       "   'id': 0}],\n",
-       " 'r_ele': [{'reb': 'かんじ',\n",
-       "   're_nokanji': False,\n",
-       "   're_restr': [],\n",
-       "   're_inf': [],\n",
-       "   're_pri': ['ichi1', 'news1', 'nf02'],\n",
-       "   'id': 0}],\n",
-       " 'sense': [{'stagk': [],\n",
-       "   'stagr': [],\n",
-       "   'pos': ['noun (common) (futsuumeishi)'],\n",
-       "   'xref': [],\n",
-       "   'ant': [],\n",
-       "   'field_': [],\n",
-       "   'misc': [],\n",
-       "   's_inf': None,\n",
-       "   'lsource': [],\n",
-       "   'dial': [],\n",
-       "   'gloss': [{'text': 'feeling', 'lang': 'eng', 'id': 0},\n",
-       "    {'text': 'sense', 'lang': 'eng', 'id': 0},\n",
-       "    {'text': 'impression', 'lang': 'eng', 'id': 0}],\n",
-       "   'id': 0}],\n",
-       " 'id': 0}"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "asdict(jmdict.feeling_lucky('感じ'))"
    ]

--- a/wsd/__main__.py
+++ b/wsd/__main__.py
@@ -1,12 +1,11 @@
 """Command line utilities."""
 import os
+
 import requests
-
 import typer
-from rich.progress import Progress, BarColumn, TextColumn, DownloadColumn, \
-    TransferSpeedColumn, TimeRemainingColumn
 from rich.console import Console
-
+from rich.progress import (BarColumn, DownloadColumn, Progress, TextColumn,
+                           TimeRemainingColumn, TransferSpeedColumn)
 
 app = typer.Typer()
 console = Console()

--- a/wsd/__main__.py
+++ b/wsd/__main__.py
@@ -1,0 +1,98 @@
+"""Command line utilities."""
+import os
+import requests
+
+import typer
+from rich.progress import Progress, BarColumn, TextColumn, DownloadColumn, \
+    TransferSpeedColumn, TimeRemainingColumn
+from rich.console import Console
+
+
+app = typer.Typer()
+console = Console()
+
+
+def download_file_from_google_drive(file_id, destination):
+    """Downloads a file from Google Drive using its file ID.
+
+    Parameters
+    ----------
+    file_id: str
+        The ID of the file on Google Drive.
+    destination: str
+        The local path where the file should be saved.
+
+    Returns
+    -------
+    The local path where the file should be saved.
+    """
+
+    # pylint: disable=invalid-name
+    def save_response_content(response, destination):
+        """Saves the content of a response to a file.
+
+        Parameters
+        ----------
+        response: requests.Response
+            The response to save.
+        destination: str
+            The local path where the file should be saved.
+        """
+        CHUNK_SIZE = 32768
+        total_size = int(response.headers.get('content-length', 0))
+        with Progress(
+            TextColumn("[bold blue]{task.fields[filename]}", justify="right"),
+            BarColumn(bar_width=None),
+            "[progress.percentage]{task.percentage:>3.1f}%",
+            "•",
+            DownloadColumn(),
+            "•",
+            TransferSpeedColumn(),
+            "•",
+            TimeRemainingColumn(),
+            console=console
+        ) as progress:
+            task_id = progress.add_task(
+                "download", filename=os.path.basename(destination), total=total_size)
+            with open(destination, "wb") as f:
+                for chunk in response.iter_content(CHUNK_SIZE):
+                    if chunk:  # filter out keep-alive new chunks
+                        f.write(chunk)
+                        progress.update(task_id, advance=len(chunk))
+
+    URL = "https://docs.google.com/uc?export=download"
+    session = requests.Session()
+    response = session.get(URL, params={'id': file_id}, stream=True)
+    params = {'id': file_id}
+    response = session.get(URL, params=params, stream=True)
+
+    save_response_content(response, destination)
+
+
+@app.command()
+def download(name: str):
+    """Download a file.
+
+    Parameters
+    ----------
+    name: str
+        The name of the file to download (currently supports 'jmdict').
+    """
+    data_dir = os.path.join(os.path.dirname(__file__), '../data')
+    os.makedirs(data_dir, exist_ok=True)
+
+    match name:
+        case 'jmdict':
+            file_id = "1dlvguHuMjDmtpA4beu1WaVbDte5j4SLk"
+            destination = os.path.join(data_dir, "JMdict_en.gz")
+            download_file_from_google_drive(file_id, destination)
+        case 'xlwsd':
+            file_id = "1d75OUrM3dyAvYUsnBXle-Z1W0NHyKIBD"
+            destination = os.path.join(data_dir, "xl-wsd-data.zip")
+            download_file_from_google_drive(file_id, destination)
+        case _:
+            print(f"Error: Unknown file name '{name}'.")
+
+
+if __name__ == "__main__":
+    app()

--- a/wsd/annotate/app.py
+++ b/wsd/annotate/app.py
@@ -1,5 +1,6 @@
 """Annotation UI for Japanese Word Sense Disambiguation."""
 # pylint: disable=unused-argument,no-member,bare-except,no-name-in-module
+# pylint: disable=too-few-public-methods,invalid-field-call
 import os
 from dataclasses import asdict, field
 

--- a/wsd/annotate/lindict.py
+++ b/wsd/annotate/lindict.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-few-public-methods
 """A simple interface for the LinDict API."""
 
 import requests
@@ -23,7 +24,7 @@ class LinDictAPI:
             A list of entries.
         """
         url = f"https://lindict.api.linalgo.com/v1/ja/search/?query={query}"
-        response = requests.get(url)
+        response = requests.get(url)  # pylint: disable=missing-timeout
         response.raise_for_status()
         if response.status_code != 200:
             return []

--- a/wsd/models/baseline.py
+++ b/wsd/models/baseline.py
@@ -94,7 +94,6 @@ class JMDict:
             start += len(token.surface)
         return doc
 
-    # pylint: disable=no-self-use
     def tokenize(self, sentence, form='all'):
         """Tokenize a sentence.
         Parameters

--- a/wsd/models/baseline.py
+++ b/wsd/models/baseline.py
@@ -1,8 +1,12 @@
+# pylint: disable=no-name-in-module,too-few-public-methods
 """A simple dictionary interface for JMDict."""
 import os
-from dataclasses import dataclass
+from collections import defaultdict
+from dataclasses import asdict, dataclass
+from typing import Any
 
-from fugashi import Tagger  # pylint: disable=no-name-in-module
+from fugashi import Tagger
+from linalgo.annotate import Annotation, Document
 
 from wsd.parsers import JMDictParser
 from wsd.parsers.jmdict import Entry
@@ -19,12 +23,105 @@ class Token:
 data_dir = os.path.join(os.path.dirname(__file__), '../../data')
 
 
+class RankingModel:
+    """Base class for the ranking models"""
+
+    def rank(self, results: list[Entry], context: Any = None):
+        """Rank results based on the given context.
+
+        Parameters
+        ----------
+        results : List[Entry]
+            A list of entries to rank
+        context : any
+            The context to use for ranking
+
+        Returns
+        -------
+        List[Entry]
+            The ranked list of entries
+        """
+        raise NotImplementedError
+
+
 class JMDict:
     """A simple dictionary interface for JMDict."""
 
-    def __init__(self, dictionary='JMdict_en.gz'):
+    def __init__(
+        self,
+        dictionary: str = 'JMdict_en.gz',
+        ranking_model: RankingModel = None
+    ):
         jmdict_file = os.path.join(data_dir, dictionary)
         self.entries = JMDictParser().parse(jmdict_file)
+        self.ranking_model = ranking_model
+        self.index = defaultdict(set)
+        self._index()
+
+    def _index(self):
+        """Create an index to speed up lookups."""
+        for entry in self.entries:
+            self.index[entry.ent_seq] = entry
+            for k_ele in entry.k_ele:
+                self.index[k_ele.keb].add(entry)
+            for r_ele in entry.r_ele:
+                self.index[r_ele.reb].add(entry)
+
+    def annotate(self, doc: Document) -> Document:
+        """Annotate a document with entry definitions.
+
+        Parameters
+        ----------
+        doc : Document
+            The document to annotate
+
+        Returns
+        -------
+        Document
+            The annotated document
+        """
+        start = 0
+        for token in self.tokenize(doc.content):
+            entry = self.feeling_lucky(token.feature.lemma)
+            if entry is not None:
+                a = Annotation(
+                    document=doc,
+                    body=asdict(entry),
+                    start=start,
+                    end=start + len(token.surface)
+                    )
+                doc.annotations.add(a)
+            start += len(token.surface)
+        return doc
+
+    def tokenize(self, sentence, form='all'):
+        """Tokenize a sentence.
+        Parameters
+        ----------
+        sentence : str
+            The sentence to tokenize
+        form : str, optional {'all', 'surface', 'lemma', 'pos'}, default 'all'
+            The type of token to return. By default 'surface'
+
+        Returns
+        -------
+        List[Token]
+            A list of tokens.
+        """
+        tagger = Tagger('-Owakati')
+        tokens = []
+        for token in tagger(sentence):
+            if form == 'all':
+                tokens.append(token)
+            elif form == 'lemma':
+                tokens.append(token.feature.lemma)
+            elif form == 'pos':
+                tokens.append(token.pos)
+            elif form == 'surface':
+                tokens.append(token.surface)
+            else:
+                raise ValueError(f'Invalid form: {form}')
+        return tokens
 
     def predict(self, sentence):
         """Predict the `ent_seq` for each token in a sentence.
@@ -39,15 +136,30 @@ class JMDict:
         preds : List[int]
             A list of predicted `ent_seq`.
         """
-
-        tagger = Tagger('-Owakati')
-
         preds = []
-        for word in tagger(sentence):
-            entry = self.feeling_lucky(word.feature.lemma)
+        for token in self.tokenize(sentence, form='lemma'):
+            entry = self.feeling_lucky(token)
             ent_seq = entry.ent_seq if entry else None
             preds.append(ent_seq)
         return preds
+
+    def get(self, ent_seq: str) -> Entry:
+        """Get an entry by its `ent_seq`.
+
+        Parameters
+        ----------
+        ent_seq : str
+            The `ent_seq` of the entry to get
+
+        Returns
+        -------
+        Entry
+            The entry with the given `ent_seq`.
+        """
+        for entry in self.entries:
+            if entry.ent_seq == ent_seq:
+                return entry
+        return None
 
     def search(self, text: str) -> list[Entry]:
         """Search for an entry by text.
@@ -65,15 +177,10 @@ class JMDict:
         List[Entry]
             A list of entries that contain the query.
         """
-        res = []
-        for entry in self.entries:
-            for k_ele in entry.k_ele:
-                if k_ele.keb == text:
-                    res.append(entry)
-            for r_ele in entry.r_ele:
-                if r_ele.reb == text:
-                    res.append(entry)
-        return res
+        results = list(self.index[text])
+        if self.ranking_model is not None:
+            results = self.ranking_model.rank(results)
+        return results
 
     def feeling_lucky(self, text: str) -> Entry:
         """Return the first entry found.

--- a/wsd/models/baseline.py
+++ b/wsd/models/baseline.py
@@ -94,6 +94,7 @@ class JMDict:
             start += len(token.surface)
         return doc
 
+    # pylint: disable=no-self-use
     def tokenize(self, sentence, form='all'):
         """Tokenize a sentence.
         Parameters

--- a/wsd/parsers/jmdict.py
+++ b/wsd/parsers/jmdict.py
@@ -128,6 +128,9 @@ class Entry:
         senses = [Sense.from_dict(s) for s in data['senses']]
         return cls(data['ent_seq'], k_ele, r_ele, senses)
 
+    def __hash__(self):
+        return int(self.ent_seq)
+
 
 # pylint: disable=too-few-public-methods
 class JMDictParser:

--- a/wsd/parsers/xlwsd.py
+++ b/wsd/parsers/xlwsd.py
@@ -1,4 +1,4 @@
-# pylint: disable=invalid-name, too-few-public-methods
+# pylint: disable=invalid-name,too-few-public-methods,too-many-locals
 """Parser for the XL-WSD dataset."""
 import os
 import xml.etree.ElementTree as ET
@@ -31,7 +31,7 @@ class XLWSDParser:
         """
         current_dir = os.path.dirname(__file__)
         filepath = os.path.join(current_dir, '../../data/xl-wsd-data.zip')
-        zf = zipfile.ZipFile(filepath, 'r')
+        zf = zipfile.ZipFile(filepath, 'r')  # pylint: disable=consider-using-with
 
         base_dir = f'xl-wsd/training_datasets/semcor_{lang}'
         labels = f'{base_dir}/semcor_{lang}.gold.key.txt'


### PR DESCRIPTION
You will need to install the latest version of https://pypi.org/project/linalgo/.

- [x] added an index to `JMDict` (100x increase in lookup speed!!!)
- [x] added `tokenize` and `annotate` method to `JMDict`
- [x] added `examples/visualize.ipynb` to demonstrate how to visuzalize annotations on documents

⚠️ the visualization only works in `jupyter notebook` and `jupyter lab` as it relies on Event Listeners in the browser that are not available in VSCode.

<img width="663" alt="Screenshot 2025-03-29 at 8 48 47" src="https://github.com/user-attachments/assets/1599dc78-8895-4aae-b339-5e1ae118c60e" />
 