### PR TITLE
feat: make jmdict an annotator

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,10 @@
 LINHUB_TOKEN=
 LINHUB_URL=https://linhub.api.linalgo.com/v1
-LINHUB_TASK=
+LINHUB_ORG=57512466-a2eb-414b-a332-ffd5486a6fb1
+LINHUB_TASK=a5040509-de9c-4757-8cb3-9087b5191a2e
+LINHUB_ENTITY=07a2fdef-d260-4f30-a350-8a7afc2af2a5
 PKG_NAME=wsd
 PJ_DIR=$PWD
 COMPOSE_FILE=./docker/vanilla/compose.yml:./compose.yml
-ALLOW_LFS=false
 FORCE_PRE_COMMIT=true
 FORCE_DOWNLOAD=true

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 ![PyPI - Version](https://img.shields.io/pypi/v/wsd)
 
-# Word Sense Disambiguation
+# Practical Word Sense Disambiguation
+
+Fast, efficient, open source & open data Word Sense Disambiguation models for practial use.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -54,17 +54,15 @@ jmdict.predict("かんじ")
 
 ## Adding more data
 
-The training data for `JMDict` is sourced from the [WSD Data Annotation Project](https://hub.linalgo.com/project/823b4545-5c97-4a22-b5f9-1bf75e620e4e).
-
 To contribute more data:
 
 - Create an account on [Linhub](https://hub.linalgo.com)
-- Add your Linhub token to the `.env` file as `LINHUB_TOKEN`
-- Run the annotation interface with the following command: `task annotate`
+- Start reviewing entries using this [interface](https://hub.linalgo.com/interfaces/rank/ranking/a5040509-de9c-4757-8cb3-9087b5191a2e)
 
-The annotation interface will be available at `https://localhost:32123/`.
+The interface has been designed to work on mobile phones to make it easy to
+contribute whenever you have 5mn available.
 
-## Training a model from scratch
+## Training a model
 
 TODO: Add instructions.
 

--- a/examples/baseline.ipynb
+++ b/examples/baseline.ipynb
@@ -21,7 +21,7 @@
     "import numpy as np\n",
     "\n",
     "from fugashi import Tagger\n",
-    "from linalgo.annotate import Sequence2SequenceTransformer\n",
+    "from linalgo.annotate import Filter, Sequence2SequenceTransformer, Pipeline\n",
     "from linalgo.hub import BQClient\n",
     "\n",
     "from wsd.models import JMDict"
@@ -36,10 +36,31 @@
     "# Fetch documents and annotations from BigQuery\n",
     "task_id = os.getenv('LINHUB_TASK')\n",
     "client = BQClient(task_id, project='linalgo-infra')\n",
+    "task = client.get_task()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Retrieve the ground truth labels\n",
+    "tagger = Tagger('-Owakati')\n",
     "\n",
-    "annotations = client.get_annotations()\n",
-    "docs = client.get_documents()\n",
-    "docs = [doc for doc in docs if len(doc.annotations) > 0]"
+    "def tokenize(text):\n",
+    "    idx = 0\n",
+    "    for token in tagger(text):\n",
+    "        yield idx, token.surface\n",
+    "        idx += len(token.surface)\n",
+    "\n",
+    "pipeline = Pipeline([\n",
+    "    Filter(exclude_annotation_fn=lambda a: a.annotator.model == 'MACHINE'),\n",
+    "    Filter(include_document_fn=lambda d: len(d.annotations) > 0),\n",
+    "    Sequence2SequenceTransformer(tokenize_fn=tokenize)\n",
+    "])\n",
+    "input_sequences, output_sequences = pipeline.transform(task)\n",
+    "y_true = np.array([yt for seq in output_sequences for yt in seq])"
    ]
   },
   {
@@ -59,30 +80,10 @@
    "source": [
     "# Use the baseline `JMDict` model to disambiguate.\n",
     "y_pred = []\n",
-    "for doc in tqdm.tqdm(docs):\n",
+    "for doc in tqdm.tqdm(task.documents):\n",
     "    yp = jmdict.predict(doc.content)\n",
     "    y_pred.extend(yp)\n",
     "y_pred = np.array(y_pred)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Retrieve the ground truth labels\n",
-    "tagger = Tagger('-Owakati')\n",
-    "\n",
-    "def tokenize(text):\n",
-    "    idx = 0\n",
-    "    for token in tagger(text):\n",
-    "        yield idx, token.surface\n",
-    "        idx += len(token.surface)\n",
-    "\n",
-    "transformer = Sequence2SequenceTransformer(tokenize_fn=tokenize)\n",
-    "input_sequences, output_sequences = transformer.transform(docs)\n",
-    "y_true = np.array([yt for seq in output_sequences for yt in seq])"
    ]
   },
   {
@@ -99,7 +100,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "wsd",
    "language": "python",
    "name": "python3"
   },

--- a/examples/baseline.ipynb
+++ b/examples/baseline.ipynb
@@ -96,6 +96,13 @@
     "acc = np.sum(y_true == y_pred) / len(y_true)\n",
     "print(f\"accuracy = {acc:%}\")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ authors = [
 dependencies = [
   "fugashi[unidic]",
   "google-cloud-bigquery",
-  "linalgo",
+  "linalgo==0.1.4",
   "mesop",
   "numpy",
   "pillow",

--- a/wsd/models/baseline.py
+++ b/wsd/models/baseline.py
@@ -1,12 +1,14 @@
 # pylint: disable=no-name-in-module,too-few-public-methods
 """A simple dictionary interface for JMDict."""
+import json
 import os
+import uuid
 from collections import defaultdict
 from dataclasses import asdict, dataclass
 from typing import Any
 
 from fugashi import Tagger
-from linalgo.annotate import Annotation, Document
+from linalgo.annotate import Annotation, Annotator, Document, Entity, Task
 
 from wsd.parsers import JMDictParser
 from wsd.parsers.jmdict import Entry
@@ -50,12 +52,21 @@ class JMDict:
     def __init__(
         self,
         dictionary: str = 'JMdict_en.gz',
-        ranking_model: RankingModel = None
+        ranking_model: RankingModel = None,
+        annotator: Annotator = None
     ):
         jmdict_file = os.path.join(data_dir, dictionary)
         self.entries = JMDictParser().parse(jmdict_file)
         self.ranking_model = ranking_model
         self.index = defaultdict(set)
+        self.annotator = annotator or Annotator(
+            id=uuid.uuid3(uuid.NAMESPACE_URL, 'jmdict').hex,
+            name='jmdict-v0',
+            model='MACHINE',
+            entity=Entity(id=os.getenv('LINHUB_ENTITY')),
+            task=Task(id=os.getenv('LINHUB_TASK'))
+        )
+
         self._index()
 
     def _index(self):
@@ -67,32 +78,48 @@ class JMDict:
             for r_ele in entry.r_ele:
                 self.index[r_ele.reb].add(entry)
 
-    def annotate(self, doc: Document) -> Document:
-        """Annotate a document with entry definitions.
+    def annotate(
+        self,
+        documents: Document | list[Document],
+        feeling_lucky=False
+    ) -> Document:
+        """Annotate each token in a document with its (candidate) definitions.
 
         Parameters
         ----------
-        doc : Document
-            The document to annotate
+        doc : Document | List[Document]
+            The documents to annotate.
 
         Returns
         -------
-        Document
-            The annotated document
+        Document | List[Document]
+            The annotated documents.
         """
-        start = 0
-        for token in self.tokenize(doc.content):
-            entry = self.feeling_lucky(token.feature.lemma)
-            if entry is not None:
-                a = Annotation(
-                    document=doc,
-                    body=asdict(entry),
-                    start=start,
-                    end=start + len(token.surface)
+        if isinstance(documents, Document):
+            documents = [documents]
+        for doc in documents:
+            start = 0
+            for token in self.tokenize(doc.content):
+                if feeling_lucky:
+                    body = asdict(self.feeling_lucky(token.feture.lemma))
+                else:
+                    entries = self.search(token.feature.lemma)
+                    body = [asdict(entry) for entry in entries]
+                if body is not None:
+                    a = Annotation(
+                        document=doc,
+                        body=json.dumps(body),
+                        start=start,
+                        end=start + len(token.surface),
+                        annotator=self.annotator,
+                        entity=self.annotator.entity,
+                        task=self.annotator.task
                     )
-                doc.annotations.add(a)
-            start += len(token.surface)
-        return doc
+                    doc.annotations.add(a)
+                start += len(token.surface)
+        if len(documents) == 1:
+            return documents[0]
+        return documents
 
     def tokenize(self, sentence, form='all'):
         """Tokenize a sentence.

--- a/wsd/models/baseline.py
+++ b/wsd/models/baseline.py
@@ -60,8 +60,8 @@ class JMDict:
         self.ranking_model = ranking_model
         self.index = defaultdict(set)
         self.annotator = annotator or Annotator(
-            id=uuid.uuid3(uuid.NAMESPACE_URL, 'jmdict').hex,
-            name='jmdict-v0',
+            id=uuid.uuid3(uuid.NAMESPACE_URL, 'jmdict-v3').hex,
+            name='jmdict-v3',
             model='MACHINE',
             entity=Entity(id=os.getenv('LINHUB_ENTITY')),
             task=Task(id=os.getenv('LINHUB_TASK'))


### PR DESCRIPTION
Two minor improvements:
- [x] `JMDict` is now a proper annotator and its annotations can be persisted on [https://hub.linalgo.com](https://hub.linalgo.com)
- [x] The annotation interface has been redesigned to be mobile first: [interfaces](https://hub.linalgo.com/interfaces/rank/ranking/a5040509-de9c-4757-8cb3-9087b5191a2e)

⚠️ The task details have changed. Please be sure to update your environment variables:

```shell
LINHUB_TOKEN=<your_personal_token_here>
LINHUB_URL=https://linhub.api.linalgo.com/v1
LINHUB_ORG=57512466-a2eb-414b-a332-ffd5486a6fb1
LINHUB_TASK=a5040509-de9c-4757-8cb3-9087b5191a2e
LINHUB_ENTITY=07a2fdef-d260-4f30-a350-8a7afc2af2a5
```

<img src="https://github.com/user-attachments/assets/abeff016-44e7-4a81-94b3-1804849441c2" width="300">
